### PR TITLE
Update repo-s3-sync to guess mimetypes

### DIFF
--- a/bin/repo-s3-sync
+++ b/bin/repo-s3-sync
@@ -22,6 +22,7 @@ import os.path
 import argparse
 import hashlib
 import datetime
+import mimetypes
 import threading
 import Queue
 from multiprocessing.dummy import Pool as ThreadPool
@@ -52,6 +53,7 @@ def printqueue_handler(printqueue):
     while True:
         print(printqueue.get(), end='')
         sys.stdout.flush()
+
 
 # setup the printqueue and its handler thread
 printqueue = Queue.Queue()
@@ -180,7 +182,16 @@ def s3_upload_dir(source_dir, bucket_name, dest_prefix, dry_run=True,
 
         if message:
             printqueue.put(message)
-        s3_client.upload_file(filename, bucket_name, dest_path)
+
+        # mime_type is None if the type can't be guessed
+        # encoding is usually None, but part of the return
+        mime_type, encoding = mimetypes.guess_type(filename)
+        if mime_type is not None:
+            extra_args = {'ContentType': mime_type}
+        else:
+            extra_args = {}
+        s3_client.upload_file(filename, bucket_name, dest_path,
+                              ExtraArgs=extra_args)
 
     pool = ThreadPool(pool_size)
     pool.map(handle_file, files_in_dir(source_dir))


### PR DESCRIPTION
@bester, I tested this on a few common file extensions, and verified that if it doesn't match (as it won't on most of the pacakge files), things will still show up as an octet-stream type. I think that's all we need in terms of mimetype/content-type to serve pages straight off of downloads.globus.org

The change is quite simple:
Use stdlib `mimetypes` package, `guess_mimetype()` on the filename, and, if a value is found, send it to AWS using the `ExtraArgs` param on boto3's `upload_file()`

Closes #4