### PR TITLE
Allow repo-s3-sync to take s3 path as an arg

### DIFF
--- a/bin/repo-s3-sync
+++ b/bin/repo-s3-sync
@@ -254,7 +254,8 @@ def parse_args():
     parser.add_argument(
         "--subdir",
         help=("Subdir of the root which we want to copy. Defaults to the "
-              "whole root dir"),
+              "whole root dir. Also joined to the dest path to specify the "
+              "matching subdir on the destination"),
         default=None)
     parser.add_argument(
         "-d", "--dryrun",
@@ -275,6 +276,10 @@ def parse_args():
         help=("The bucket into which to copy files [downloads.globus.org]"),
         default='downloads.globus.org')
     parser.add_argument(
+        "--s3-path",
+        help=("The dest path into which to copy files [toolkit/gt6]"),
+        default='toolkit/gt6')
+    parser.add_argument(
         "--compare-method",
         help=("The method by which local files and S3 objects are compared in "
               "order to determine whether or not to upload [checksum]"),
@@ -293,7 +298,7 @@ def main():
 
     # for clarity's sake: this does not need to have a trailing slash, but it
     # will be treated as a dirname on the destination
-    upload_prefix = 'data/toolkit/gt6'
+    upload_prefix = os.path.join('data/', args.s3_path)
 
     source_dir = args.root
 

--- a/share/doc/repo-s3-sync.html
+++ b/share/doc/repo-s3-sync.html
@@ -24,6 +24,11 @@ used with <span class="strong"><strong>--pool-size</strong></span></p></div><div
 </span></dt><dd>
     Display files that would be copied, but don’t actually execute the copy
 </dd><dt><span class="term">
+<span class="strong"><strong>--delete</strong></span>
+</span></dt><dd>
+    Do a sync-delete operation, removing files not in the source dir after
+    uploading is complete. Recommend using <span class="strong"><strong>--verbose</strong></span> with this flag
+</dd><dt><span class="term">
 <span class="strong"><strong>-v, --verbose</strong></span>
 </span></dt><dd>
     Be verbose about checks and uploads, list every file
@@ -31,6 +36,12 @@ used with <span class="strong"><strong>--pool-size</strong></span></p></div><div
 <span class="strong"><strong>--s3-bucket BUCKETNAME</strong></span>
 </span></dt><dd>
     Sync to <span class="strong"><strong>BUCKETNAME</strong></span>, defaults to <code class="literal">downloads.globus.org</code>
+</dd><dt><span class="term">
+<span class="strong"><strong>--s3-path PATH</strong></span>
+</span></dt><dd>
+    Path prefix to use in <span class="strong"><strong>BUCKETNAME</strong></span>, defaults to <code class="literal">toolkit/gt6</code>
+    Will have <code class="literal">data/</code> prepended, as all writes to the S3 bucket go into the
+    <code class="literal">data/</code> namespace
 </dd><dt><span class="term">
 <span class="strong"><strong>--compare-method METHOD</strong></span>
 </span></dt><dd>

--- a/share/doc/repo-s3-sync.txt
+++ b/share/doc/repo-s3-sync.txt
@@ -52,6 +52,10 @@ OPTIONS
     Be verbose about checks and uploads, list every file
 *--s3-bucket BUCKETNAME*::
     Sync to *BUCKETNAME*, defaults to +downloads.globus.org+
+*--s3-path PATH*::
+    Path prefix to use in *BUCKETNAME*, defaults to +toolkit/gt6+
+    Will have +data/+ prepended, as all writes to the S3 bucket go into the
+    +data/+ namespace
 *--compare-method METHOD*::
     How to compare files against S3. One of 'checksum', 'size', 'modified'
     (i.e. mtime vs. S3 modified time), 'nocheck'. Defaults to 'checksum'

--- a/share/man/man1/repo-s3-sync.1
+++ b/share/man/man1/repo-s3-sync.1
@@ -2,12 +2,12 @@
 .\"     Title: repo-s3-sync
 .\"    Author: [see the "AUTHOR" section]
 .\" Generator: DocBook XSL Stylesheets v1.79.1 <http://docbook.sf.net/>
-.\"      Date: 12/27/2016
+.\"      Date: 03/06/2017
 .\"    Manual: Globus Toolkit Manual
 .\"    Source: globus-release-tools
 .\"  Language: English
 .\"
-.TH "REPO\-S3\-SYNC" "1" "12/27/2016" "globus\-release\-tools" "Globus Toolkit Manual"
+.TH "REPO\-S3\-SYNC" "1" "03/06/2017" "globus\-release\-tools" "Globus Toolkit Manual"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------
@@ -85,6 +85,18 @@ Be verbose about checks and uploads, list every file
 Sync to
 \fBBUCKETNAME\fR, defaults to
 downloads\&.globus\&.org
+.RE
+.PP
+\fB\-\-s3\-path PATH\fR
+.RS 4
+Path prefix to use in
+\fBBUCKETNAME\fR, defaults to
+toolkit/gt6
+Will have
+data/
+prepended, as all writes to the S3 bucket go into the
+data/
+namespace
 .RE
 .PP
 \fB\-\-compare\-method METHOD\fR


### PR DESCRIPTION
Default is `toolkit/gt6/`, but you can specify any other path.
All paths have `data/` prefixed onto them, as that's the part of s3://downloads.globus.org that's writable via this tool.

@bester, I think this satisfies your needs.
I've also updated the S3 creds to allow you to write to `data/globus-connect-server/`

Usage will look like

```bash
# default behavior, but if you wanted it explicitly
$ repo-s3-sync ... --s3-path toolkit/gt6
# new behavior you'll want to use
$ repo-s3-sync ... --s3-path globus-connect-server
```