### PR TITLE
remove old gpg-agent management code

### DIFF
--- a/bin/repo-promote-package
+++ b/bin/repo-promote-package
@@ -113,8 +113,6 @@ if socket.gethostname() == 'globuscvs':
     os.umask(0o2)
     repo.gid = gid
 
-repo.setup_gpg_agent()
-
 releases = [args.from_release, args.to_release]
 
 print("====================")

--- a/bin/repo-regenerate-metadata
+++ b/bin/repo-regenerate-metadata
@@ -72,8 +72,6 @@ if socket.gethostname() == 'globuscvs':
     os.umask(0o2)
     repo.gid = gid
 
-repo.setup_gpg_agent()
-
 print("====================")
 print("Parsing repositories")
 print("====================")

--- a/share/python/repo/__init__.py
+++ b/share/python/repo/__init__.py
@@ -447,20 +447,4 @@ class Manager(object):
         return result
 
 
-def setup_gpg_agent():
-    if os.getenv("GPG_AGENT_INFO") is None:
-        proc = Popen(
-            [
-                "/usr/bin/gpg-agent",
-                "--daemon",
-                "--default-cache-ttl", "14400",
-                "--max-cache-ttl", "14400"
-            ],
-            stdout=PIPE)
-        (procout, procerr) = proc.communicate()
-        var, val = procout.split(";")[0].split("=")
-        os.putenv(var, val)
-        procpid = int(val.split(":")[1])
-        atexit.register(lambda x: os.kill(x, signal.SIGTERM), procpid)
-
 # vim: filetype=python:

--- a/share/python/repo/zypper.py
+++ b/share/python/repo/zypper.py
@@ -234,11 +234,8 @@ DATADIR RPMS
         content_asc = os.path.join(distro_repodir, "content.asc")
         if os.path.exists(content_asc):
             os.remove(content_asc)
-        if os.getenv("GPG_AGENT_INFO") is not None:
-            os.system("cd \"%s\"; gpg --batch --use-agent -ab content" %
-                      (distro_repodir))
-        else:
-            os.system("cd \"%s\"; gpg -ab content" % (distro_repodir))
+        os.system("cd \"%s\"; gpg --batch --use-agent -ab content" %
+                  (distro_repodir))
         self.create_index(distro_repodir, recursive=True)
 
 


### PR DESCRIPTION
`gpg-agent` on ubuntu doesn't need to be manually started (it also doesn't need the PID saved in order to kill it). This removes the now-unnecessary setup steps.